### PR TITLE
Fix compatibility issue with typed properties

### DIFF
--- a/includes/class-dragon-zap-affiliate.php
+++ b/includes/class-dragon-zap-affiliate.php
@@ -10,13 +10,25 @@ final class Dragon_Zap_Affiliate
     private const NONCE_ACTION = 'dragon_zap_affiliate_test';
     private const API_BASE_URI = 'https://affiliate.dragonzap.com/api/v1';
 
-    private static ?self $instance = null;
+    /**
+     * @var self|null
+     */
+    private static $instance = null;
 
-    private string $plugin_file;
+    /**
+     * @var string
+     */
+    private $plugin_file;
 
-    private ?string $settings_page_hook = null;
+    /**
+     * @var string|null
+     */
+    private $settings_page_hook = null;
 
-    private bool $sdk_autoloader_registered = false;
+    /**
+     * @var bool
+     */
+    private $sdk_autoloader_registered = false;
 
     private function __construct(string $plugin_file)
     {


### PR DESCRIPTION
## Summary
- replace typed class properties with PHP 7 compatible definitions to avoid syntax errors on older runtimes

## Testing
- php -l includes/class-dragon-zap-affiliate.php

------
https://chatgpt.com/codex/tasks/task_e_68e5244474bc832c8a0db1752f2abb12