### PR TITLE
Fix PHP 8.0 syntax errors in SDK

### DIFF
--- a/DragonZapAffiliateApiPhpSdk/src/Http/CurlHttpClient.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Http/CurlHttpClient.php
@@ -6,11 +6,15 @@ use RuntimeException;
 
 class CurlHttpClient implements HttpClientInterface
 {
-    public function __construct(private readonly ?float $timeout = 10.0)
+    private ?float $timeout;
+
+    public function __construct(?float $timeout = 10.0)
     {
         if (!function_exists('curl_init')) {
             throw new RuntimeException('cURL extension is required to use CurlHttpClient.');
         }
+
+        $this->timeout = $timeout;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Http/Response.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Http/Response.php
@@ -4,14 +4,23 @@ namespace DragonZap\AffiliateApi\Http;
 
 class Response
 {
+    private int $statusCode;
+
+    /**
+     * @var array<string, array<int, string>|string>
+     */
+    private array $headers;
+
+    private string $body;
+
     /**
      * @param array<string, array<int, string>|string> $headers
      */
-    public function __construct(
-        private readonly int $statusCode,
-        private readonly array $headers,
-        private readonly string $body
-    ) {
+    public function __construct(int $statusCode, array $headers, string $body)
+    {
+        $this->statusCode = $statusCode;
+        $this->headers = $headers;
+        $this->body = $body;
     }
 
     public function getStatusCode(): int

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/BlogProfilesResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/BlogProfilesResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class BlogProfilesResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/BlogsResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/BlogsResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class BlogsResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/CategoriesResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/CategoriesResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class CategoriesResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/ProductsResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/ProductsResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class ProductsResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/PromotionsResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/PromotionsResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class PromotionsResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**

--- a/DragonZapAffiliateApiPhpSdk/src/Resources/WebhooksResource.php
+++ b/DragonZapAffiliateApiPhpSdk/src/Resources/WebhooksResource.php
@@ -6,8 +6,11 @@ use DragonZap\AffiliateApi\Client;
 
 class WebhooksResource
 {
-    public function __construct(private readonly Client $client)
+    private Client $client;
+
+    public function __construct(Client $client)
     {
+        $this->client = $client;
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace readonly constructor property promotion with traditional properties so the SDK can load on PHP 8.0
- ensure HTTP response and resource classes store their state without PHP 8.1-only syntax

## Testing
- find DragonZapAffiliateApiPhpSdk/src -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68e525441988832c9043c61f277f4d32