### PR TITLE
Show Affiliate API test route in scope results

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,45 @@
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-scope-details {
+    margin-top: 1em;
+    padding-top: 1em;
+    border-top: 1px solid #dcdcde;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-scope-block {
+    flex: 1 1 220px;
+    min-width: 200px;
+}
+
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-scope-block h3 {
+    margin: 0 0 0.5em;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: #1d2327;
+}
+
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-scope-list {
+    margin: 0;
+    padding-left: 1.1em;
+    list-style: disc;
+}
+
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-scope-block .description {
+    margin: 0;
+    color: #50575e;
+}
+
+#dragon-zap-affiliate-test-result .dragon-zap-affiliate-endpoint {
+    display: inline-block;
+    margin: 0 0 0.5em;
+    padding: 0.25em 0.5em;
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    border-radius: 3px;
+    font-family: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 12px;
+    color: #1d2327;
+    word-break: break-all;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,18 +1,102 @@
 (function ($) {
     'use strict';
 
-    function setResult(message, type) {
-        var $result = $('#dragon-zap-affiliate-test-result');
-        $result.removeClass('notice notice-success notice-error notice-warning');
+    var settings = window.dragonZapAffiliate || {};
 
-        if (!message) {
-            $result.empty();
+    function getString(key, fallback) {
+        var value = settings[key];
+
+        if (typeof value === 'string' && value.length > 0) {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    function getResultContainer() {
+        return $('#dragon-zap-affiliate-test-result');
+    }
+
+    function clearResult() {
+        var $result = getResultContainer();
+        $result.removeClass('notice notice-success notice-error notice-warning');
+        $result.empty();
+    }
+
+    function createScopeBlock(title, items, emptyMessage, description) {
+        var $block = $('<div>').addClass('dragon-zap-affiliate-scope-block');
+
+        if (title) {
+            $block.append($('<h3>').text(title));
+        }
+
+        if (Array.isArray(items) && items.length) {
+            var $list = $('<ul>').addClass('dragon-zap-affiliate-scope-list');
+
+            items.forEach(function (item) {
+                $list.append($('<li>').text(item));
+            });
+
+            $block.append($list);
+        } else if (emptyMessage) {
+            $block.append($('<p>').addClass('description').text(emptyMessage));
+        }
+
+        if (description) {
+            $block.append($('<p>').addClass('description').text(description));
+        }
+
+        return $block;
+    }
+
+    function createEndpointBlock(title, url, description) {
+        var $block = $('<div>').addClass('dragon-zap-affiliate-scope-block');
+
+        if (title) {
+            $block.append($('<h3>').text(title));
+        }
+
+        if (url) {
+            $block.append(
+                $('<code>')
+                    .addClass('dragon-zap-affiliate-endpoint')
+                    .attr('aria-label', title || getString('endpointTitle', 'Affiliate test endpoint'))
+                    .text(url)
+            );
+        }
+
+        if (description) {
+            $block.append($('<p>').addClass('description').text(description));
+        }
+
+        return $block;
+    }
+
+    function renderResult(type, message, blocks) {
+        var $result = getResultContainer();
+
+        clearResult();
+
+        if (!message && (!Array.isArray(blocks) || !blocks.length)) {
             return;
         }
 
         var cssClass = type === 'success' ? 'notice-success' : 'notice-error';
         $result.addClass('notice ' + cssClass);
-        $result.text(message);
+
+        if (message) {
+            $result.append($('<p>').text(message));
+        }
+
+        if (Array.isArray(blocks) && blocks.length) {
+            var $details = $('<div>').addClass('dragon-zap-affiliate-scope-details');
+
+            blocks.forEach(function ($block) {
+                $details.append($block);
+            });
+
+            $result.append($details);
+        }
     }
 
     $(function () {
@@ -23,14 +107,14 @@
             return;
         }
 
-        var originalText = dragonZapAffiliate.buttonLabel || $button.text();
+        var originalText = getString('buttonLabel', $button.text());
 
         $button.on('click', function (event) {
             event.preventDefault();
 
-            setResult('', '');
+            clearResult();
             $button.prop('disabled', true);
-            $button.text(dragonZapAffiliate.testingText || 'Testing...');
+            $button.text(getString('testingText', 'Testing...'));
 
             $.ajax({
                 url: window.ajaxurl,
@@ -38,18 +122,53 @@
                 dataType: 'json',
                 data: {
                     action: 'dza_test_connection',
-                    nonce: dragonZapAffiliate.nonce,
+                    nonce: settings.nonce,
                     api_key: $apiField.val()
                 }
             }).done(function (response) {
-                if (response.success) {
-                    setResult(response.data.message || dragonZapAffiliate.testSuccessMessage, 'success');
+                if (response && response.success) {
+                    var apiResponse = response.data && response.data.response ? response.data.response : {};
+                    var payload = apiResponse.data && typeof apiResponse.data === 'object' ? apiResponse.data : {};
+                    var scopes = Array.isArray(payload.scopes) ? payload.scopes : [];
+                    var restrictions = Array.isArray(payload.restrictions) ? payload.restrictions : [];
+
+                    var blocks = [
+                        createScopeBlock(
+                            getString('scopesTitle', 'Authorized scopes'),
+                            scopes,
+                            getString('scopesEmpty', 'No scopes were returned for this API key.')
+                        ),
+                        createScopeBlock(
+                            getString('restrictionsTitle', 'Restricted scopes'),
+                            restrictions,
+                            getString('restrictionsEmpty', 'No restricted scopes were reported for this API key.'),
+                            getString('restrictionsHelp', '')
+                        )
+                    ];
+
+                    var endpointUrl = getString('testEndpointUrl', '');
+
+                    if (endpointUrl) {
+                        blocks.push(
+                            createEndpointBlock(
+                                getString('endpointTitle', 'Affiliate test endpoint'),
+                                endpointUrl,
+                                getString('endpointDescription', '')
+                            )
+                        );
+                    }
+
+                    renderResult(
+                        'success',
+                        (response.data && response.data.message) || getString('testSuccessMessage', 'Connection successful!'),
+                        blocks
+                    );
                 } else {
-                    var message = response.data && response.data.message ? response.data.message : dragonZapAffiliate.testErrorMessage;
-                    setResult(message, 'error');
+                    var message = response && response.data && response.data.message ? response.data.message : getString('testErrorMessage', 'Connection failed. Please check your API key and try again.');
+                    renderResult('error', message);
                 }
             }).fail(function () {
-                setResult(dragonZapAffiliate.testErrorMessage, 'error');
+                renderResult('error', getString('testErrorMessage', 'Connection failed. Please check your API key and try again.'));
             }).always(function () {
                 $button.prop('disabled', false);
                 $button.text(originalText);

--- a/includes/class-dragon-zap-affiliate.php
+++ b/includes/class-dragon-zap-affiliate.php
@@ -115,6 +115,13 @@ final class Dragon_Zap_Affiliate
             return;
         }
 
+        wp_enqueue_style(
+            'dragon-zap-affiliate-admin',
+            $this->plugin_url('assets/css/admin.css'),
+            [],
+            $this->plugin_version()
+        );
+
         wp_enqueue_script(
             'dragon-zap-affiliate-admin',
             $this->plugin_url('assets/js/admin.js'),
@@ -132,6 +139,14 @@ final class Dragon_Zap_Affiliate
                 'testingText' => __('Testing...', 'dragon-zap-affiliate'),
                 'testSuccessMessage' => __('Connection successful!', 'dragon-zap-affiliate'),
                 'testErrorMessage' => __('Connection failed. Please check your API key and try again.', 'dragon-zap-affiliate'),
+                'scopesTitle' => __('Authorized scopes', 'dragon-zap-affiliate'),
+                'scopesEmpty' => __('No scopes were returned for this API key.', 'dragon-zap-affiliate'),
+                'restrictionsTitle' => __('Restricted scopes', 'dragon-zap-affiliate'),
+                'restrictionsEmpty' => __('No restricted scopes were reported for this API key.', 'dragon-zap-affiliate'),
+                'restrictionsHelp' => __('Restricted scopes require additional approval. Contact Dragon Zap support to request access.', 'dragon-zap-affiliate'),
+                'endpointTitle' => __('Affiliate test endpoint', 'dragon-zap-affiliate'),
+                'endpointDescription' => __('Scopes are returned from the Affiliate API test endpoint below. You can call it directly with your API key to review the raw response.', 'dragon-zap-affiliate'),
+                'testEndpointUrl' => trailingslashit($this->get_api_base_uri()) . 'test',
             ]
         );
     }


### PR DESCRIPTION
## Summary
- pass the Affiliate API test endpoint URL to the admin script so it can be displayed with the scope details
- render a third information block on successful tests that shows the `/test` route and explains it returns scope data
- style the endpoint output to look like inline code so the route is easy to spot

## Testing
- php -l includes/class-dragon-zap-affiliate.php

------
https://chatgpt.com/codex/tasks/task_e_68e52a10ad54832c9ff7843fdca39786