### PR TITLE
Add Gutenberg block for related courses widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ WordPress plugin that integrates with the Dragon Zap Affiliate API.
 
 * Store and validate your Dragon Zap Affiliate API credentials from the WordPress admin settings page.
 * Automatically append a "Recommended Courses" widget to single blog posts using the Dragon Zap Affiliate product search.
-* Register a sidebar widget so the related courses list can be repositioned in any widget area.
+* Register both a classic widget and a block editor widget so the related courses list can be repositioned in any widget area.
 
 ## Related Courses Widget
 
 The plugin analyses the current blog post title, tags, and categories to query the Dragon Zap Affiliate API for up to three matching courses. Results are cached for 12 hours per post to minimise API calls and are refreshed automatically when the post is updated.
 
 Widget output includes the course title, featured image, price, and a short description with affiliate tracking links. Styling is provided via the bundled `assets/css/related-courses.css` file and adapts to the context when displayed in content or a sidebar.
+
+In block-based themes or the Widgets screen, add the **Dragon Zap Related Courses** block to any widget area. The block provides simple controls to toggle and customise the widget heading, and renders the same content as the classic widget on the front end.

--- a/assets/css/block-related-courses-editor.css
+++ b/assets/css/block-related-courses-editor.css
@@ -1,0 +1,10 @@
+.dragon-zap-affiliate-related-courses-block-preview {
+    border: 1px dashed #8c8f94;
+    padding: 16px;
+    background: #f6f7f7;
+    color: #2c3338;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview p {
+    margin: 0;
+}

--- a/assets/js/block-related-courses.js
+++ b/assets/js/block-related-courses.js
@@ -1,0 +1,58 @@
+(function (blocks, element, i18n, components) {
+    var el = element.createElement;
+    var __ = i18n.__;
+    var InspectorControls = (wp.blockEditor && wp.blockEditor.InspectorControls) || (wp.editor && wp.editor.InspectorControls);
+    var PanelBody = components.PanelBody;
+    var TextControl = components.TextControl;
+    var ToggleControl = components.ToggleControl;
+
+    blocks.registerBlockType('dragon-zap-affiliate/related-courses', {
+        title: __('Dragon Zap Related Courses', 'dragon-zap-affiliate'),
+        description: __('Display Dragon Zap courses that are related to the current post.', 'dragon-zap-affiliate'),
+        icon: 'welcome-learn-more',
+        category: 'widgets',
+        supports: {
+            html: false,
+        },
+        attributes: {
+            title: {
+                type: 'string',
+                default: __('Recommended Courses', 'dragon-zap-affiliate'),
+            },
+            showTitle: {
+                type: 'boolean',
+                default: true,
+            },
+        },
+        edit: function (props) {
+            var attributes = props.attributes;
+
+            return [
+                el(InspectorControls, { key: 'controls' },
+                    el(PanelBody, { title: __('Display Settings', 'dragon-zap-affiliate'), initialOpen: true },
+                        el(ToggleControl, {
+                            label: __('Show heading', 'dragon-zap-affiliate'),
+                            checked: attributes.showTitle,
+                            onChange: function (value) {
+                                props.setAttributes({ showTitle: value });
+                            },
+                        }),
+                        attributes.showTitle && el(TextControl, {
+                            label: __('Heading text', 'dragon-zap-affiliate'),
+                            value: attributes.title,
+                            onChange: function (value) {
+                                props.setAttributes({ title: value });
+                            },
+                        })
+                    )
+                ),
+                el('div', { className: 'dragon-zap-affiliate-related-courses-block-preview', key: 'preview' },
+                    el('p', {}, __('Related courses will be shown on single posts after the content.', 'dragon-zap-affiliate'))
+                )
+            ];
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp.blocks, window.wp.element, window.wp.i18n, window.wp.components);

--- a/dragon-zap-affiliate.php
+++ b/dragon-zap-affiliate.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Dragon Zap Affiliate
  * Description: Integrates WordPress with the Dragon Zap Affiliate API.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author: Dragon Zap
  * Requires PHP: 8.0
  * License: GPL-2.0-or-later


### PR DESCRIPTION
## Summary
- add a block editor block for the related courses widget with heading controls
- register block assets and server-side rendering so the block matches the classic widget output
- document the new block option and bump the plugin version to 0.3.0

## Testing
- php -l includes/class-dragon-zap-affiliate.php

------
https://chatgpt.com/codex/tasks/task_e_68e52fb48384832ca0aef1949a105bf9