### PR TITLE
Add widget placement toggle and styling customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ WordPress plugin that integrates with the Dragon Zap Affiliate API.
 ## Features
 
 * Store and validate your Dragon Zap Affiliate API credentials from the WordPress admin settings page.
-* Automatically append a "Recommended Courses" widget to single blog posts using the Dragon Zap Affiliate product search.
-* Register both a classic widget and a block editor widget so the related courses list can be repositioned in any widget area.
+* Optionally append a "Recommended Courses" widget to single blog posts using the Dragon Zap Affiliate product search.
+* Register both a classic widget and a block editor widget so the related courses list can be repositioned or removed entirely.
 
 ## Related Courses Widget
 
 The plugin analyses the current blog post title, tags, and categories to query the Dragon Zap Affiliate API for up to three matching courses. Results are cached for 12 hours per post to minimise API calls and are refreshed automatically when the post is updated.
 
-Widget output includes the course title, featured image, price, and a short description with affiliate tracking links. Styling is provided via the bundled `assets/css/related-courses.css` file and adapts to the context when displayed in content or a sidebar.
+Widget output includes the course title, featured image, price, and a short description with affiliate tracking links. Styling is provided via the bundled `assets/css/related-courses.css` file and adapts to the context when displayed in content or a sidebar. You can customise the widget appearance (colours, visibility of images/descriptions/prices, and additional CSS classes) from either the Widgets screen or the block inspector controls.
 
-In block-based themes or the Widgets screen, add the **Dragon Zap Related Courses** block to any widget area. The block provides simple controls to toggle and customise the widget heading, and renders the same content as the classic widget on the front end.
+In block-based themes or the Widgets screen, add the **Dragon Zap Related Courses** block to any widget area. The block provides controls to toggle the heading, switch on or off specific course details, adjust colours, and supply custom CSS classes while rendering the same content as the classic widget on the front end. A new setting in **Settings → Dragon Zap Affiliate** lets you disable the automatic placement so you can position the widget or block exactly where you need it.

--- a/assets/css/related-courses.css
+++ b/assets/css/related-courses.css
@@ -1,23 +1,30 @@
+
 .dragon-zap-affiliate-related-courses {
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
+    --dza-related-bg: #ffffff;
+    --dza-related-border: #e2e8f0;
+    --dza-related-text: #0f172a;
+    --dza-related-muted: #475569;
+    --dza-related-accent: #1d4ed8;
+    --dza-related-radius: 8px;
+    --dza-related-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--dza-related-border);
+    border-radius: var(--dza-related-radius);
     padding: 1.5rem;
-    background-color: #ffffff;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    background-color: var(--dza-related-bg);
+    box-shadow: var(--dza-related-shadow);
     margin: 2rem 0;
+    color: var(--dza-related-text);
 }
 
 .dragon-zap-affiliate-related-courses--widget {
     margin: 0;
-    padding: 0;
-    border: none;
     box-shadow: none;
-    background: none;
 }
 
 .dragon-zap-affiliate-related-courses__heading {
     font-size: 1.25rem;
     margin: 0 0 1rem;
+    color: inherit;
 }
 
 .dragon-zap-affiliate-related-courses__list {
@@ -34,6 +41,10 @@
     align-items: flex-start;
 }
 
+.dragon-zap-affiliate-related-courses--no-images .dragon-zap-affiliate-related-courses__item {
+    align-items: stretch;
+}
+
 .dragon-zap-affiliate-related-courses__image {
     width: 96px;
     height: 96px;
@@ -42,13 +53,17 @@
     display: block;
 }
 
+.dragon-zap-affiliate-related-courses__image-link {
+    flex-shrink: 0;
+}
+
 .dragon-zap-affiliate-related-courses__content {
     flex: 1 1 auto;
 }
 
 .dragon-zap-affiliate-related-courses__title {
     font-weight: 600;
-    color: #1d4ed8;
+    color: var(--dza-related-accent);
     text-decoration: none;
 }
 
@@ -60,11 +75,12 @@
 .dragon-zap-affiliate-related-courses__price {
     font-weight: 600;
     margin-top: 0.25rem;
+    color: var(--dza-related-accent);
 }
 
 .dragon-zap-affiliate-related-courses__description {
     margin: 0.5rem 0 0;
-    color: #475569;
+    color: var(--dza-related-muted);
     font-size: 0.95rem;
     line-height: 1.4;
 }

--- a/assets/js/block-related-courses.js
+++ b/assets/js/block-related-courses.js
@@ -57,6 +57,38 @@
                 type: 'boolean',
                 default: true,
             },
+            showImages: {
+                type: 'boolean',
+                default: true,
+            },
+            showDescription: {
+                type: 'boolean',
+                default: true,
+            },
+            showPrice: {
+                type: 'boolean',
+                default: true,
+            },
+            backgroundColor: {
+                type: 'string',
+                default: '',
+            },
+            textColor: {
+                type: 'string',
+                default: '',
+            },
+            accentColor: {
+                type: 'string',
+                default: '',
+            },
+            borderColor: {
+                type: 'string',
+                default: '',
+            },
+            customClass: {
+                type: 'string',
+                default: '',
+            },
         },
         edit: function (props) {
             var attributes = props.attributes;
@@ -77,11 +109,73 @@
                             onChange: function (value) {
                                 props.setAttributes({ title: value });
                             },
+                        }),
+                        el(ToggleControl, {
+                            label: __('Show course images', 'dragon-zap-affiliate'),
+                            checked: attributes.showImages,
+                            onChange: function (value) {
+                                props.setAttributes({ showImages: value });
+                            },
+                        }),
+                        el(ToggleControl, {
+                            label: __('Show descriptions', 'dragon-zap-affiliate'),
+                            checked: attributes.showDescription,
+                            onChange: function (value) {
+                                props.setAttributes({ showDescription: value });
+                            },
+                        }),
+                        el(ToggleControl, {
+                            label: __('Show prices', 'dragon-zap-affiliate'),
+                            checked: attributes.showPrice,
+                            onChange: function (value) {
+                                props.setAttributes({ showPrice: value });
+                            },
+                        })
+                    ),
+                    el(PanelBody, { title: __('Style Settings', 'dragon-zap-affiliate'), initialOpen: false },
+                        el(TextControl, {
+                            label: __('Background color', 'dragon-zap-affiliate'),
+                            placeholder: '#ffffff',
+                            value: attributes.backgroundColor,
+                            onChange: function (value) {
+                                props.setAttributes({ backgroundColor: value });
+                            },
+                        }),
+                        el(TextControl, {
+                            label: __('Text color', 'dragon-zap-affiliate'),
+                            placeholder: '#0f172a',
+                            value: attributes.textColor,
+                            onChange: function (value) {
+                                props.setAttributes({ textColor: value });
+                            },
+                        }),
+                        el(TextControl, {
+                            label: __('Link & accent color', 'dragon-zap-affiliate'),
+                            placeholder: '#1d4ed8',
+                            value: attributes.accentColor,
+                            onChange: function (value) {
+                                props.setAttributes({ accentColor: value });
+                            },
+                        }),
+                        el(TextControl, {
+                            label: __('Border color', 'dragon-zap-affiliate'),
+                            placeholder: '#e2e8f0',
+                            value: attributes.borderColor,
+                            onChange: function (value) {
+                                props.setAttributes({ borderColor: value });
+                            },
+                        }),
+                        el(TextControl, {
+                            label: __('Additional CSS classes', 'dragon-zap-affiliate'),
+                            value: attributes.customClass,
+                            onChange: function (value) {
+                                props.setAttributes({ customClass: value });
+                            },
                         })
                     )
                 ),
                 el('div', { className: 'dragon-zap-affiliate-related-courses-block-preview', key: 'preview' },
-                    el('p', {}, __('Related courses will be shown on single posts after the content.', 'dragon-zap-affiliate'))
+                    el('p', {}, __('Related courses will be shown on single posts after the content or wherever you place this block.', 'dragon-zap-affiliate'))
                 )
             ];
         },

--- a/includes/class-dragon-zap-affiliate-related-courses-widget.php
+++ b/includes/class-dragon-zap-affiliate-related-courses-widget.php
@@ -43,12 +43,29 @@ class Dragon_Zap_Affiliate_Related_Courses_Widget extends WP_Widget
         $title = isset($instance['title']) ? (string) $instance['title'] : __('Recommended Courses', 'dragon-zap-affiliate');
         $title = apply_filters('widget_title', $title, $instance, $this->id_base);
 
+        $show_images = ! isset($instance['show_images']) || (bool) $instance['show_images'];
+        $show_description = ! isset($instance['show_description']) || (bool) $instance['show_description'];
+        $show_price = ! isset($instance['show_price']) || (bool) $instance['show_price'];
+        $background_color = isset($instance['background_color']) ? (string) $instance['background_color'] : '';
+        $text_color = isset($instance['text_color']) ? (string) $instance['text_color'] : '';
+        $accent_color = isset($instance['accent_color']) ? (string) $instance['accent_color'] : '';
+        $border_color = isset($instance['border_color']) ? (string) $instance['border_color'] : '';
+        $custom_class = isset($instance['custom_class']) ? (string) $instance['custom_class'] : '';
+
         $markup = '';
 
         if ($post_id > 0) {
             $markup = $plugin->get_related_courses_markup($post_id, [
                 'title' => '',
                 'context' => 'widget',
+                'show_images' => $show_images,
+                'show_description' => $show_description,
+                'show_price' => $show_price,
+                'background_color' => $background_color,
+                'text_color' => $text_color,
+                'accent_color' => $accent_color,
+                'border_color' => $border_color,
+                'custom_class' => $custom_class,
             ]);
         }
 
@@ -81,12 +98,54 @@ class Dragon_Zap_Affiliate_Related_Courses_Widget extends WP_Widget
     public function form($instance)
     {
         $title = isset($instance['title']) ? (string) $instance['title'] : __('Recommended Courses', 'dragon-zap-affiliate');
+        $show_images = ! isset($instance['show_images']) || (bool) $instance['show_images'];
+        $show_description = ! isset($instance['show_description']) || (bool) $instance['show_description'];
+        $show_price = ! isset($instance['show_price']) || (bool) $instance['show_price'];
+        $background_color = isset($instance['background_color']) ? (string) $instance['background_color'] : '';
+        $text_color = isset($instance['text_color']) ? (string) $instance['text_color'] : '';
+        $accent_color = isset($instance['accent_color']) ? (string) $instance['accent_color'] : '';
+        $border_color = isset($instance['border_color']) ? (string) $instance['border_color'] : '';
+        $custom_class = isset($instance['custom_class']) ? (string) $instance['custom_class'] : '';
         $field_id = $this->get_field_id('title');
         $field_name = $this->get_field_name('title');
         ?>
         <p>
             <label for="<?php echo esc_attr($field_id); ?>"><?php esc_html_e('Title:', 'dragon-zap-affiliate'); ?></label>
             <input class="widefat" id="<?php echo esc_attr($field_id); ?>" name="<?php echo esc_attr($field_name); ?>" type="text" value="<?php echo esc_attr($title); ?>" />
+        </p>
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_images')); ?>" name="<?php echo esc_attr($this->get_field_name('show_images')); ?>" value="1" <?php checked($show_images); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_images')); ?>"><?php esc_html_e('Display course images', 'dragon-zap-affiliate'); ?></label>
+        </p>
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_description')); ?>" name="<?php echo esc_attr($this->get_field_name('show_description')); ?>" value="1" <?php checked($show_description); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_description')); ?>"><?php esc_html_e('Display course descriptions', 'dragon-zap-affiliate'); ?></label>
+        </p>
+        <p>
+            <input type="checkbox" id="<?php echo esc_attr($this->get_field_id('show_price')); ?>" name="<?php echo esc_attr($this->get_field_name('show_price')); ?>" value="1" <?php checked($show_price); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_price')); ?>"><?php esc_html_e('Display course prices', 'dragon-zap-affiliate'); ?></label>
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('background_color')); ?>"><?php esc_html_e('Background color:', 'dragon-zap-affiliate'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('background_color')); ?>" name="<?php echo esc_attr($this->get_field_name('background_color')); ?>" type="text" value="<?php echo esc_attr($background_color); ?>" placeholder="#ffffff" />
+            <span class="description"><?php esc_html_e('Leave blank to use the default widget background.', 'dragon-zap-affiliate'); ?></span>
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('text_color')); ?>"><?php esc_html_e('Text color:', 'dragon-zap-affiliate'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('text_color')); ?>" name="<?php echo esc_attr($this->get_field_name('text_color')); ?>" type="text" value="<?php echo esc_attr($text_color); ?>" placeholder="#0f172a" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('accent_color')); ?>"><?php esc_html_e('Link & accent color:', 'dragon-zap-affiliate'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('accent_color')); ?>" name="<?php echo esc_attr($this->get_field_name('accent_color')); ?>" type="text" value="<?php echo esc_attr($accent_color); ?>" placeholder="#1d4ed8" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('border_color')); ?>"><?php esc_html_e('Border color:', 'dragon-zap-affiliate'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('border_color')); ?>" name="<?php echo esc_attr($this->get_field_name('border_color')); ?>" type="text" value="<?php echo esc_attr($border_color); ?>" placeholder="#e2e8f0" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('custom_class')); ?>"><?php esc_html_e('Additional CSS classes:', 'dragon-zap-affiliate'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('custom_class')); ?>" name="<?php echo esc_attr($this->get_field_name('custom_class')); ?>" type="text" value="<?php echo esc_attr($custom_class); ?>" />
+            <span class="description"><?php esc_html_e('Separate multiple classes with spaces.', 'dragon-zap-affiliate'); ?></span>
         </p>
         <?php
     }
@@ -96,6 +155,33 @@ class Dragon_Zap_Affiliate_Related_Courses_Widget extends WP_Widget
         $instance = [];
         $instance['title'] = isset($new_instance['title']) ? sanitize_text_field($new_instance['title']) : '';
 
+        $instance['show_images'] = ! empty($new_instance['show_images']);
+        $instance['show_description'] = ! empty($new_instance['show_description']);
+        $instance['show_price'] = ! empty($new_instance['show_price']);
+
+        $instance['background_color'] = $this->sanitize_color_value(isset($new_instance['background_color']) ? $new_instance['background_color'] : '');
+        $instance['text_color'] = $this->sanitize_color_value(isset($new_instance['text_color']) ? $new_instance['text_color'] : '');
+        $instance['accent_color'] = $this->sanitize_color_value(isset($new_instance['accent_color']) ? $new_instance['accent_color'] : '');
+        $instance['border_color'] = $this->sanitize_color_value(isset($new_instance['border_color']) ? $new_instance['border_color'] : '');
+        $instance['custom_class'] = isset($new_instance['custom_class']) ? sanitize_text_field($new_instance['custom_class']) : '';
+
         return $instance;
+    }
+
+    private function sanitize_color_value($value): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $sanitized = sanitize_hex_color($value);
+
+        return is_string($sanitized) ? $sanitized : '';
     }
 }


### PR DESCRIPTION
## Summary
- add an admin setting so the related courses widget can be toggled on or off for automatic placement on posts
- expand the block and classic widget controls to allow hiding elements, changing colours, and adding custom classes
- refresh the shared stylesheet and documentation to reflect the new customisation options

## Testing
- php -l includes/class-dragon-zap-affiliate.php
- php -l includes/class-dragon-zap-affiliate-related-courses-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e65a44a3a4832c8c01b3f383d8fc5a