### PR TITLE
Add live related courses preview to block editor

### DIFF
--- a/assets/css/block-related-courses-editor.css
+++ b/assets/css/block-related-courses-editor.css
@@ -3,8 +3,98 @@
     padding: 16px;
     background: #f6f7f7;
     color: #2c3338;
+    border-radius: 4px;
 }
 
-.dragon-zap-affiliate-related-courses-block-preview p {
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses {
+    --dza-related-bg: #ffffff;
+    --dza-related-border: #e2e8f0;
+    --dza-related-text: #0f172a;
+    --dza-related-muted: #475569;
+    --dza-related-accent: #1d4ed8;
+    --dza-related-radius: 8px;
+    --dza-related-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--dza-related-border);
+    border-radius: var(--dza-related-radius);
+    padding: 1.5rem;
+    background-color: var(--dza-related-bg);
+    box-shadow: var(--dza-related-shadow);
     margin: 0;
+    color: var(--dza-related-text);
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__heading {
+    font-size: 1.25rem;
+    margin: 0 0 1rem;
+    color: inherit;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__item {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses--no-images .dragon-zap-affiliate-related-courses__item {
+    align-items: stretch;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__image {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 6px;
+    display: block;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__image-link {
+    flex-shrink: 0;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__content {
+    flex: 1 1 auto;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__title {
+    font-weight: 600;
+    color: var(--dza-related-accent);
+    text-decoration: none;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__title:hover,
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__title:focus {
+    text-decoration: underline;
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__price {
+    font-weight: 600;
+    margin-top: 0.25rem;
+    color: var(--dza-related-accent);
+}
+
+.dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__description {
+    margin: 0.5rem 0 0;
+    color: var(--dza-related-muted);
+    font-size: 0.95rem;
+    line-height: 1.4;
+}
+
+@media (max-width: 600px) {
+    .dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dragon-zap-affiliate-related-courses-block-preview .dragon-zap-affiliate-related-courses__image {
+        width: 100%;
+        height: auto;
+    }
 }

--- a/assets/js/block-related-courses.js
+++ b/assets/js/block-related-courses.js
@@ -117,6 +117,121 @@
                 previewProps.className = previewClass;
             }
 
+            var preventPreviewNavigation = function (event) {
+                if (event && typeof event.preventDefault === 'function') {
+                    event.preventDefault();
+                }
+            };
+
+            var escapeForSvg = function (value) {
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            };
+
+            var placeholderLabel = escapeForSvg(__('Course', 'dragon-zap-affiliate'));
+            var placeholderSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">' +
+                '<rect width="96" height="96" rx="12" fill="#e2e8f0" />' +
+                '<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="12" fill="#475569" font-family="Arial, sans-serif">' +
+                placeholderLabel +
+                '</text>' +
+                '</svg>';
+            var placeholderImage = 'data:image/svg+xml;utf8,' + encodeURIComponent(placeholderSvg);
+
+            var sampleCourses = [
+                {
+                    title: __('Unity 3D Starter Kit', 'dragon-zap-affiliate'),
+                    description: __('Build your first real-time game world while mastering Unity fundamentals.', 'dragon-zap-affiliate'),
+                    price: 'USD 19.99',
+                },
+                {
+                    title: __('Master Unreal Blueprints', 'dragon-zap-affiliate'),
+                    description: __('Create gameplay systems visually and prototype ideas faster than ever.', 'dragon-zap-affiliate'),
+                    price: 'USD 29.99',
+                },
+                {
+                    title: __('Game Design Bootcamp', 'dragon-zap-affiliate'),
+                    description: __('Learn to balance mechanics, narrative, and player experience like a pro.', 'dragon-zap-affiliate'),
+                    price: 'USD 24.99',
+                },
+            ];
+
+            var containerClasses = ['dragon-zap-affiliate-related-courses', 'dragon-zap-affiliate-related-courses--block'];
+
+            if (!attributes.showImages) {
+                containerClasses.push('dragon-zap-affiliate-related-courses--no-images');
+            }
+
+            if (attributes.customClass) {
+                containerClasses.push(attributes.customClass);
+            }
+
+            var styleVariables = {};
+
+            if (attributes.backgroundColor) {
+                styleVariables['--dza-related-bg'] = attributes.backgroundColor;
+            }
+
+            if (attributes.textColor) {
+                styleVariables['--dza-related-text'] = attributes.textColor;
+                styleVariables['--dza-related-muted'] = attributes.textColor;
+            }
+
+            if (attributes.accentColor) {
+                styleVariables['--dza-related-accent'] = attributes.accentColor;
+            }
+
+            if (attributes.borderColor) {
+                styleVariables['--dza-related-border'] = attributes.borderColor;
+            }
+
+            var headingText = attributes.showTitle
+                ? (attributes.title || __('Recommended Courses', 'dragon-zap-affiliate'))
+                : '';
+
+            var courseItems = sampleCourses.map(function (course, index) {
+                var imageElement = null;
+
+                if (attributes.showImages) {
+                    imageElement = el('a', {
+                        className: 'dragon-zap-affiliate-related-courses__image-link',
+                        href: '#',
+                        onClick: preventPreviewNavigation,
+                    },
+                        el('img', {
+                            className: 'dragon-zap-affiliate-related-courses__image',
+                            src: placeholderImage,
+                            alt: course.title,
+                            loading: 'lazy',
+                        })
+                    );
+                }
+
+                var priceElement = attributes.showPrice
+                    ? el('div', { className: 'dragon-zap-affiliate-related-courses__price' }, course.price)
+                    : null;
+
+                var descriptionElement = attributes.showDescription
+                    ? el('p', { className: 'dragon-zap-affiliate-related-courses__description' }, course.description)
+                    : null;
+
+                return el('li', { key: 'course-' + index, className: 'dragon-zap-affiliate-related-courses__item' },
+                    imageElement,
+                    el('div', { className: 'dragon-zap-affiliate-related-courses__content' },
+                        el('a', {
+                            className: 'dragon-zap-affiliate-related-courses__title',
+                            href: '#',
+                            onClick: preventPreviewNavigation,
+                        }, course.title),
+                        priceElement,
+                        descriptionElement
+                    )
+                );
+            });
+
             return [
                 el(InspectorControls, { key: 'controls' },
                     el(PanelBody, { title: __('Display Settings', 'dragon-zap-affiliate'), initialOpen: true },
@@ -239,7 +354,15 @@
                     )
                 ),
                 el('div', previewProps,
-                    el('p', {}, __('Related courses will be shown on single posts after the content or wherever you place this block.', 'dragon-zap-affiliate'))
+                    el('div', {
+                        className: containerClasses.join(' '),
+                        style: Object.keys(styleVariables).length ? styleVariables : undefined,
+                    },
+                        headingText !== ''
+                            ? el('h2', { className: 'dragon-zap-affiliate-related-courses__heading' }, headingText)
+                            : null,
+                        el('ul', { className: 'dragon-zap-affiliate-related-courses__list' }, courseItems)
+                    )
                 )
             ];
         },


### PR DESCRIPTION
## Summary
- replace the placeholder message in the related courses block with a live sample preview that reflects editor settings
- add editor-only styles so the preview mirrors the front-end widget appearance and responds to custom colors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e666c22f50832c90acb48e57608929