### PR TITLE
Fix auto append related courses to content

### DIFF
--- a/includes/class-dragon-zap-affiliate.php
+++ b/includes/class-dragon-zap-affiliate.php
@@ -43,6 +43,7 @@ final class Dragon_Zap_Affiliate
         add_action('init', [$this, 'register_frontend_assets']);
         add_action('init', [$this, 'register_blocks']);
         add_action('widgets_init', [$this, 'register_widgets']);
+        add_filter('the_content', [$this, 'append_related_courses_to_content']);
       
         add_action('save_post', [$this, 'clear_related_courses_cache']);
         add_action('delete_post', [$this, 'clear_related_courses_cache']);


### PR DESCRIPTION
## Summary
- hook the related courses renderer into `the_content` so the automatic append option works as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7838065e8832ca72fa21d58eeb3e8